### PR TITLE
Gov -> gov migraton now works

### DIFF
--- a/To do.md
+++ b/To do.md
@@ -1,7 +1,11 @@
 # To do
 
-- clear cache after first login occurs so that FedRAMP -> FedRAMP migration works
-  - https://stackoverflow.com/a/58659476
+- retest migration tool; fork and pull request migration tool
+- request api app for sacramento dev
+
+
+
+
 
 - initialize `sourceComplianceLevel` and `destComplianceLevel` to the default values that are used in the .html instead of hardcoding their initial values to match those from the .html
 

--- a/electron/main.js
+++ b/electron/main.js
@@ -114,6 +114,12 @@ app.whenReady().then(function() {
     redirectUrls.push(details.url); // the URL that OAuth redirects us to
     console.log('redirectUrls', redirectUrls);
     redirected = true;
+    
+    /* Clear cookies before redirecting. If we don't do this, then when we log into the second account,
+    the login cookie from the first account will be used, and the second login will thus be erroneously ignored. */
+    mainWindow.webContents.session.clearStorageData({storages: ['cookies']}); // using no arguments seems like it should work, but it causes an error
+
+    /* Cancel the redirect and manually load index.html. */
     const currentWindow = BrowserWindow.getFocusedWindow();
     configLoadRendererAfterDOMContentLoaded(currentWindow);
     callback({ cancel: true });


### PR DESCRIPTION
Cookies are now cleared in-between logins. If we don't do this, then when we log into the second account, the login cookie from the first account will be used, and the second login will thus be erroneously ignored.